### PR TITLE
Updates related to new message encoding changes

### DIFF
--- a/src/main/java/io/socket/java/protocol/Packet.java
+++ b/src/main/java/io/socket/java/protocol/Packet.java
@@ -30,8 +30,8 @@ public abstract class Packet implements MessagePackable {
 
 	@Override
 	public void writeTo(Packer packer) throws IOException {
-		packer.writeArrayBegin(2);
-		
+		packer.writeArrayBegin(3);
+		packer.write("emitter");		
 		packer.writeMapBegin(3);
 		packer.write("type");
 		packer.write(this.type);


### PR DESCRIPTION
Changes to formation of encoded changes made to a packet of a publish event with respect to socket.io: 3.0.5 & socket.io-redis: 6.0.1
We tested it to be working with above changes made, while integrating at our end.